### PR TITLE
Update global time from time.is

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,12 +149,19 @@
 
         async function initGlobalTime(){
             try{
-                const res = await fetch('https://worldtimeapi.org/api/timezone/Europe/Rome');
-                const data = await res.json();
-                globalTimeOffset = new Date(data.datetime).getTime() - Date.now();
+                const res = await fetch('https://time.is/Unix_time_now');
+                const txt = await res.text();
+                const serverNow = parseInt(txt.trim(),10)*1000;
+                globalTimeOffset = serverNow - Date.now();
             }catch(err){
-                console.error('Impossibile sincronizzare l’ora: uso l’orologio del dispositivo', err);
-                globalTimeOffset = 0;
+                try{
+                    const res = await fetch('https://worldtimeapi.org/api/timezone/Europe/Rome');
+                    const data = await res.json();
+                    globalTimeOffset = new Date(data.datetime).getTime() - Date.now();
+                }catch(err2){
+                    console.error('Impossibile sincronizzare l\u2019ora: uso l\u2019orologio del dispositivo', err2);
+                    globalTimeOffset = 0;
+                }
             }
         }
         const getGlobalNow = () => new Date(Date.now()+globalTimeOffset);


### PR DESCRIPTION
## Summary
- fetch time from `https://time.is/Unix_time_now` for device-independent clock
- fallback to the previous worldtimeapi provider if the `time.is` request fails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68591b5efda48320b70f7e30e2fae84c