### PR TITLE
Improve upcoming green schedule modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,8 +42,10 @@
         #schedule-modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,.5);justify-content:center;align-items:center;z-index:1001}
         #schedule-modal .modal-content{background:#fff;border-radius:12px;padding:20px;max-height:80vh;overflow-y:auto;box-shadow:var(--box-shadow-heavy);width:90vw;max-width:500px}
         #schedule-modal .modal-close{float:right;cursor:pointer;font-size:1.5em}
-        .day-schedule{margin-bottom:15px}
-        .schedule-times{font-size:.9em;line-height:1.4em}
+        #schedule-filter{display:flex;background-color:var(--toggle-bg);border-radius:15px;padding:5px;margin-bottom:15px;justify-content:center}
+        .filter-btn{padding:8px 20px;font-size:1em;font-weight:700;color:var(--toggle-text-color);background:transparent;border:none;border-radius:12px;cursor:pointer;flex-grow:1;transition:.3s}
+        .filter-btn.active{background:var(--toggle-active-bg);color:var(--toggle-active-text-color);box-shadow:0 2px 8px rgba(0,0,0,.2)}
+        .schedule-list{list-style:none;padding:0;margin:0;text-align:center;font-size:1.2em}
 
         #install-button{background:var(--install-button-bg);color:var(--install-button-text);border:none;border-radius:var(--install-button-border-radius);padding:12px 25px;font-size:1.1em;font-weight:700;cursor:pointer;box-shadow:var(--box-shadow-light);transition:background-color .3s,transform .1s;margin-top:30px;margin-bottom:20px;display:none}
         #install-button:hover{background:var(--install-button-hover-bg);transform:translateY(-2px)}
@@ -90,8 +92,12 @@
     <div id="schedule-modal">
         <div class="modal-content">
             <span id="schedule-close" class="modal-close">&times;</span>
-            <h2 style="margin-top:0">Orari verde <span id="schedule-name"></span></h2>
-            <div id="schedule-content"></div>
+            <h2 style="margin-top:0">Prossimi verdi</h2>
+            <div id="schedule-filter">
+                <button id="filter-orezzo" class="filter-btn">Orezzo</button>
+                <button id="filter-gazzaniga" class="filter-btn">Gazzaniga</button>
+            </div>
+            <ul id="schedule-content" class="schedule-list"></ul>
         </div>
     </div>
 
@@ -165,8 +171,10 @@
         const scheduleButton        = document.getElementById('schedule-button');
         const scheduleModal         = document.getElementById('schedule-modal');
         const scheduleContent       = document.getElementById('schedule-content');
-        const scheduleName          = document.getElementById('schedule-name');
+        const filterOrezzoBtn       = document.getElementById('filter-orezzo');
+        const filterGazzanigaBtn    = document.getElementById('filter-gazzaniga');
         const scheduleClose         = document.getElementById('schedule-close');
+        let scheduleView            = 'orezzo';
         let deferredPrompt, currentSemaforo='orezzo';
 
         /* ---------- Orologio globale (fuso Europa/Roma) ---------- */
@@ -197,38 +205,37 @@
         /* ---------- Utility ---------- */
         const formatTimeSeconds = s => `${String(Math.floor(s/60)).padStart(2,'0')}:${String(Math.floor(s%60)).padStart(2,'0')}`;
 
-        /* ---------- Calcolo orari verdi ---------- */
-        function computeSchedule(refGreen){
+        /* ---------- Calcolo prossimi orari verdi ---------- */
+        function computeUpcoming(refGreen, hours=4){
             const now = getGlobalNow();
-            const days = [];
-            for(let d=0; d<10; d++){
-                const dayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()+d,0,0,0);
-                const dayEnd = new Date(dayStart.getTime()+24*60*60*1000);
-                const times=[];
-                let t = refGreen + Math.ceil((dayStart.getTime()-refGreen)/totalCycleDuration)*totalCycleDuration;
-                while(t < dayEnd.getTime()){
-                    times.push(new Date(t));
-                    t += totalCycleDuration;
-                }
-                days.push({date:dayStart,times});
+            const end = new Date(now.getTime()+hours*60*60*1000);
+            const times=[];
+            let t = refGreen + Math.ceil((now.getTime()-refGreen)/totalCycleDuration)*totalCycleDuration;
+            while(t <= end.getTime()){
+                times.push(new Date(t));
+                t += totalCycleDuration;
             }
-            return days;
+            return times;
+        }
+
+        function updateScheduleList(){
+            const ref = scheduleView==='orezzo'?orezzoRefGreenTime:gazzanigaRefGreenTime;
+            const times = computeUpcoming(ref);
+            filterOrezzoBtn.classList.toggle('active', scheduleView==='orezzo');
+            filterGazzanigaBtn.classList.toggle('active', scheduleView==='gazzaniga');
+            scheduleContent.innerHTML = times.map(t=>`<li>${t.toLocaleTimeString('it-IT',{hour:'2-digit',minute:'2-digit',second:'2-digit',timeZone:'Europe/Rome'})}</li>`).join('');
         }
 
         function openSchedule(){
-            const ref = currentSemaforo==='orezzo'?orezzoRefGreenTime:gazzanigaRefGreenTime;
-            const schedule = computeSchedule(ref);
-            scheduleName.textContent = currentSemaforo==='orezzo' ? 'Orezzo' : 'Gazzaniga';
-            scheduleContent.innerHTML = schedule.map(d=>{
-                const dateStr = d.date.toLocaleDateString('it-IT',{timeZone:'Europe/Rome'});
-                const times = d.times.map(t=>t.toLocaleTimeString('it-IT',{hour:'2-digit',minute:'2-digit',second:'2-digit',timeZone:'Europe/Rome'})).join(', ');
-                return `<div class="day-schedule"><strong>${dateStr}</strong><div class="schedule-times">${times}</div></div>`;
-            }).join('');
+            scheduleView = currentSemaforo;
+            updateScheduleList();
             scheduleModal.style.display='flex';
         }
         scheduleButton.addEventListener('click',openSchedule);
         scheduleClose.addEventListener('click',()=>{scheduleModal.style.display='none';});
         scheduleModal.addEventListener('click',e=>{if(e.target===scheduleModal) scheduleModal.style.display='none';});
+        filterOrezzoBtn.addEventListener('click',()=>{scheduleView='orezzo';updateScheduleList();});
+        filterGazzanigaBtn.addEventListener('click',()=>{scheduleView='gazzaniga';updateScheduleList();});
 
         /* ---------- Aggiorna semaforo ---------- */
         function updateLight(el, refGreen){


### PR DESCRIPTION
## Summary
- rework schedule popup UI with filter buttons
- list only next four hours of green times
- add Italian time format and filter actions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685ab700a48883208948c95aeeb43eb1