### PR TITLE
Improve upcoming green lights schedule UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,10 @@
         .filter-btn{padding:8px 20px;font-size:1em;font-weight:700;color:var(--toggle-text-color);background:transparent;border:none;border-radius:12px;cursor:pointer;flex-grow:1;transition:.3s}
         .filter-btn.active{background:var(--toggle-active-bg);color:var(--toggle-active-text-color);box-shadow:0 2px 8px rgba(0,0,0,.2)}
         .schedule-list{list-style:none;padding:0;margin:0;text-align:center;font-size:1.2em}
+        .schedule-group{margin-bottom:15px}
+        .group-hour{font-weight:700;margin-bottom:5px;font-size:1.2em}
+        .group-times{display:flex;flex-wrap:wrap;gap:6px;justify-content:center}
+        .time-pill{background:var(--toggle-bg);border-radius:8px;padding:5px 10px;min-width:48px}
 
         #install-button{background:var(--install-button-bg);color:var(--install-button-text);border:none;border-radius:var(--install-button-border-radius);padding:12px 25px;font-size:1.1em;font-weight:700;cursor:pointer;box-shadow:var(--box-shadow-light);transition:background-color .3s,transform .1s;margin-top:30px;margin-bottom:20px;display:none}
         #install-button:hover{background:var(--install-button-hover-bg);transform:translateY(-2px)}
@@ -68,6 +72,7 @@
             .light{width:80px;height:80px}
             .time-display{max-width:280px}.time-display p{font-size:1.1em}
             #install-button{padding:10px 20px;font-size:1em}
+            .time-pill{padding:4px 8px;font-size:.9em}
         }
         @media (max-width:480px){
             #main-title{font-size:1.8em}
@@ -76,6 +81,7 @@
             .light{width:70px;height:70px}
             .time-display{max-width:250px;padding:15px}.time-display p{font-size:1em}
             #install-button{padding:8px 15px;font-size:.9em}
+            .time-pill{padding:3px 6px;font-size:.8em}
         }
     </style>
 </head>
@@ -97,7 +103,7 @@
                 <button id="filter-orezzo" class="filter-btn">Orezzo</button>
                 <button id="filter-gazzaniga" class="filter-btn">Gazzaniga</button>
             </div>
-            <ul id="schedule-content" class="schedule-list"></ul>
+            <div id="schedule-content" class="schedule-list"></div>
         </div>
     </div>
 
@@ -223,7 +229,22 @@
             const times = computeUpcoming(ref);
             filterOrezzoBtn.classList.toggle('active', scheduleView==='orezzo');
             filterGazzanigaBtn.classList.toggle('active', scheduleView==='gazzaniga');
-            scheduleContent.innerHTML = times.map(t=>`<li>${t.toLocaleTimeString('it-IT',{hour:'2-digit',minute:'2-digit',second:'2-digit',timeZone:'Europe/Rome'})}</li>`).join('');
+
+            const groups=[];
+            times.forEach(t=>{
+                const hour = t.toLocaleTimeString('it-IT',{hour:'2-digit',timeZone:'Europe/Rome',hour12:false});
+                const mmss = t.toLocaleTimeString('it-IT',{minute:'2-digit',second:'2-digit',timeZone:'Europe/Rome'});
+                let g=groups[groups.length-1];
+                if(!g || g.hour!==hour){
+                    g={hour,list:[]};
+                    groups.push(g);
+                }
+                g.list.push(mmss);
+            });
+
+            scheduleContent.innerHTML = groups.map(g=>
+                `<div class="schedule-group"><div class="group-hour">${g.hour}</div><div class="group-times">${g.list.map(t=>`<span class="time-pill">${t}</span>`).join('')}</div></div>`
+            ).join('');
         }
 
         function openSchedule(){


### PR DESCRIPTION
## Summary
- display upcoming green times grouped by hour
- style schedule modal with mobile-optimized pill layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b5d4d697c83209e0c9d383ea0995e