### PR TITLE
Update schedule popup layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,13 +49,12 @@
         .schedule-group{margin-bottom:15px}
         .group-hour{font-weight:700;margin-bottom:5px;font-size:1.2em}
         .group-times{display:flex;flex-wrap:wrap;gap:6px;justify-content:center}
-        .time-pill{background:var(--toggle-bg);border-radius:8px;padding:5px 10px;min-width:48px}
+        .time-pill{background:var(--toggle-bg);border-radius:8px;padding:5px 10px;display:inline-block;min-width:48px;font-weight:700;margin:2px}
 
         .schedule-table{width:100%;border-collapse:collapse;font-size:1.1em;margin-top:10px}
         .schedule-table th,.schedule-table td{border:1px solid #e0e0e0;padding:6px;text-align:center;vertical-align:top}
         .schedule-table th{background:var(--toggle-bg);font-weight:700}
-        .hour-pill{background:var(--toggle-bg);border-radius:50%;padding:6px 10px;display:inline-block;font-weight:700}
-        .minute-pill{background:var(--toggle-bg);border-radius:12px;padding:2px 6px;display:inline-block;margin-right:2px;font-weight:700}
+        .hour-pill{background:var(--toggle-bg);border-radius:8px;padding:5px 10px;display:inline-block;min-width:48px;font-weight:700}
         .seconds-text{font-size:.9em;margin-left:2px}
 
         #install-button{background:var(--install-button-bg);color:var(--install-button-text);border:none;border-radius:var(--install-button-border-radius);padding:12px 25px;font-size:1.1em;font-weight:700;cursor:pointer;box-shadow:var(--box-shadow-light);transition:background-color .3s,transform .1s;margin-top:30px;margin-bottom:20px;display:none}
@@ -80,7 +79,6 @@
             .time-display{max-width:280px}.time-display p{font-size:1.1em}
             #install-button{padding:10px 20px;font-size:1em}
             .time-pill{padding:4px 8px;font-size:.9em}
-            .minute-pill{padding:4px 8px;font-size:.9em}
         }
         @media (max-width:480px){
             #main-title{font-size:1.8em}
@@ -90,7 +88,6 @@
             .time-display{max-width:250px;padding:15px}.time-display p{font-size:1em}
             #install-button{padding:8px 15px;font-size:.9em}
             .time-pill{padding:3px 6px;font-size:.8em}
-            .minute-pill{padding:3px 6px;font-size:.8em}
         }
     </style>
 </head>
@@ -250,11 +247,11 @@
             });
 
             const hours = Object.keys(groups).sort((a,b)=>parseInt(a,10)-parseInt(b,10));
-            let html = '<table class="schedule-table"><thead><tr><th>Ora</th><th>00-09</th><th>10-19</th><th>20-29</th><th>30-39</th><th>40-49</th><th>50-59</th></tr></thead><tbody>';
+            let html = '<table class="schedule-table"><thead><tr><th>Ora</th>' + '<th></th>'.repeat(6) + '</tr></thead><tbody>';
             hours.forEach(h=>{
                 html += `<tr><td><span class="hour-pill">${h}</span></td>`;
                 [0,10,20,30,40,50].forEach(b=>{
-                    const list = groups[h][b].map(t=>`<span class="minute-pill">${t.minute}</span><span class="seconds-text">${t.second}</span>`).join('<br>');
+                    const list = groups[h][b].map(t=>`<span class="time-pill">${t.minute}<span class="seconds-text">:${t.second}</span></span>`).join(' ');
                     html += `<td>${list}</td>`;
                 });
                 html += '</tr>';


### PR DESCRIPTION
## Summary
- make time pills uniform and inline
- simplify schedule popup header

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bc5dfab4c832082b8ec968c3249ac