### PR TITLE
Improve schedule modal layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,7 @@
 
         #schedule-modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,.5);justify-content:center;align-items:center;z-index:1001}
         #schedule-modal .modal-content{background:#fff;border-radius:12px;padding:20px;max-height:80vh;overflow-y:auto;box-shadow:var(--box-shadow-heavy);width:90vw;max-width:500px}
+        #schedule-content{overflow-x:auto}
         #schedule-modal .modal-close{float:right;cursor:pointer;font-size:1.5em}
         #schedule-filter{display:flex;background-color:var(--toggle-bg);border-radius:15px;padding:5px;margin-bottom:15px;justify-content:center}
         .filter-btn{padding:8px 20px;font-size:1em;font-weight:700;color:var(--toggle-text-color);background:transparent;border:none;border-radius:12px;cursor:pointer;flex-grow:1;transition:.3s}
@@ -51,11 +52,11 @@
         .group-times{display:flex;flex-wrap:wrap;gap:6px;justify-content:center}
         .time-pill{background:var(--toggle-bg);border-radius:8px;padding:5px 10px;display:inline-block;min-width:48px;font-weight:700;margin:2px}
 
-        .schedule-table{width:100%;border-collapse:collapse;font-size:1.1em;margin-top:10px}
+        .schedule-table{width:100%;border-collapse:collapse;font-size:1.1em;margin-top:10px;table-layout:fixed}
         .schedule-table th,.schedule-table td{border:1px solid #e0e0e0;padding:6px;text-align:center;vertical-align:top}
         .schedule-table th{background:var(--toggle-bg);font-weight:700}
-        .hour-pill{background:var(--toggle-bg);border-radius:8px;padding:5px 10px;display:inline-block;min-width:48px;font-weight:700}
-        .seconds-text{font-size:.9em;margin-left:2px}
+        .hour-pill{background:var(--toggle-bg);border-radius:8px;padding:5px 10px;display:inline-block;min-width:48px;font-weight:700;position:relative}
+        .hour-pill::after{content:'h';color:var(--toggle-active-bg);margin-left:3px;font-weight:700}
 
         #install-button{background:var(--install-button-bg);color:var(--install-button-text);border:none;border-radius:var(--install-button-border-radius);padding:12px 25px;font-size:1.1em;font-weight:700;cursor:pointer;box-shadow:var(--box-shadow-light);transition:background-color .3s,transform .1s;margin-top:30px;margin-bottom:20px;display:none}
         #install-button:hover{background:var(--install-button-hover-bg);transform:translateY(-2px)}
@@ -79,6 +80,7 @@
             .time-display{max-width:280px}.time-display p{font-size:1.1em}
             #install-button{padding:10px 20px;font-size:1em}
             .time-pill{padding:4px 8px;font-size:.9em}
+            .schedule-table{font-size:1em}
         }
         @media (max-width:480px){
             #main-title{font-size:1.8em}
@@ -88,6 +90,8 @@
             .time-display{max-width:250px;padding:15px}.time-display p{font-size:1em}
             #install-button{padding:8px 15px;font-size:.9em}
             .time-pill{padding:3px 6px;font-size:.8em}
+            .schedule-table{font-size:.9em}
+            .schedule-table th,.schedule-table td{padding:4px}
         }
     </style>
 </head>
@@ -240,10 +244,9 @@
             times.forEach(t=>{
                 const hour   = t.toLocaleTimeString('it-IT',{hour:'2-digit',timeZone:'Europe/Rome',hour12:false});
                 const minute = t.toLocaleTimeString('it-IT',{minute:'2-digit',timeZone:'Europe/Rome'});
-                const second = t.toLocaleTimeString('it-IT',{second:'2-digit',timeZone:'Europe/Rome'});
                 const band   = Math.floor(parseInt(minute,10)/10)*10;
                 if(!groups[hour]) groups[hour] = {0:[],10:[],20:[],30:[],40:[],50:[]};
-                groups[hour][band].push({minute,second});
+                groups[hour][band].push({minute});
             });
 
             const hours = Object.keys(groups).sort((a,b)=>parseInt(a,10)-parseInt(b,10));
@@ -251,7 +254,7 @@
             hours.forEach(h=>{
                 html += `<tr><td><span class="hour-pill">${h}</span></td>`;
                 [0,10,20,30,40,50].forEach(b=>{
-                    const list = groups[h][b].map(t=>`<span class="time-pill">${t.minute}<span class="seconds-text">:${t.second}</span></span>`).join(' ');
+                    const list = groups[h][b].map(t=>`<span class="time-pill">${t.minute}</span>`).join(' ');
                     html += `<td>${list}</td>`;
                 });
                 html += '</tr>';


### PR DESCRIPTION
## Summary
- optimize schedule table for mobile by using fixed layout and smaller fonts
- show hours with an `h` suffix and remove seconds from list
- allow horizontal scrolling of schedule table

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685bc80cc0f083208ba9f5ea6e427558