### PR TITLE
Shift timings after blackout

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,8 +183,8 @@
         const totalCycleDuration = greenDuration + orangeDuration + redDuration;
 
         /* ---------- Timestamp di riferimento ---------- */
-        const orezzoRefGreenTime    = new Date('2025-06-05T11:28:42+02:00').getTime();
-        const gazzanigaRefGreenTime = new Date('2025-06-03T12:57:15+02:00').getTime();
+        const orezzoRefGreenTime    = new Date('2025-06-05T11:28:58+02:00').getTime();
+        const gazzanigaRefGreenTime = new Date('2025-06-03T12:57:31+02:00').getTime();
 
         /* ---------- Elementi DOM ---------- */
         const orezzoElements = {container:document.getElementById('orezzo-display-area'),red:document.getElementById('orezzo-red-light'),orange:document.getElementById('orezzo-orange-light'),green:document.getElementById('orezzo-green-light'),currentTime:document.getElementById('orezzo-current-time'),timeInPhase:document.getElementById('orezzo-time-in-phase')};


### PR DESCRIPTION
## Summary
- adjust reference timestamps for Orezzo and Gazzaniga by 16 seconds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686547a372d48320ae72f0ae2abb228e