### PR TITLE
Shift Orezzo timings 15s earlier

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,7 +183,7 @@
         const totalCycleDuration = greenDuration + orangeDuration + redDuration;
 
         /* ---------- Timestamp di riferimento ---------- */
-        const orezzoRefGreenTime    = new Date('2025-06-05T11:28:58+02:00').getTime();
+        const orezzoRefGreenTime    = new Date('2025-06-05T11:28:43+02:00').getTime();
         const gazzanigaRefGreenTime = new Date('2025-06-03T12:57:31+02:00').getTime();
 
         /* ---------- Elementi DOM ---------- */


### PR DESCRIPTION
## Summary
- adjust Orezzo reference green timestamp back by 15s

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686e1b769d408320bdf66dc7087d6f72